### PR TITLE
use the `audit.k8s.io` v1 version.

### DIFF
--- a/containerd/scripts/clean.sh
+++ b/containerd/scripts/clean.sh
@@ -15,6 +15,8 @@
 
 nerdctl stop sealer-registry && nerdctl rmi -f sealer-registry
 systemctl stop containerd
+systemctl disable containerd
+systemctl daemon-reload
 
 rm -f /usr/bin/conntrack
 rm -f /usr/bin/kubelet-pre-start.sh
@@ -35,10 +37,15 @@ rm -f /usr/bin/vpnkit
 rm -f /usr/bin/containerd-rootless-setuptool.sh
 rm -f /usr/bin/containerd-rootless.sh
 rm -f /usr/bin/nerdctl
+rm -f /usr/bin/seautil
 
 rm -f /etc/sysctl.d/k8s.conf
+rm -f /etc/crictl.yaml
 rm -f /etc/systemd/system/kubelet.service
 rm -rf /etc/systemd/system/kubelet.service.d
+rm -rf /etc/ld.so.conf.d/containerd.conf
 rm -rf /var/lib/kubelet/
+rm -rf /var/lib/containerd
+rm -rf /var/lib/nerdctl
 rm -f /var/lib/kubelet/config.yaml
-rm -f /etc/crictl.yaml
+rm -rf /opt/containerd

--- a/rootfs/statics/audit-policy.yml
+++ b/rootfs/statics/audit-policy.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: audit.k8s.io/v1beta1 # This is required.
+apiVersion: audit.k8s.io/v1 # This is required.
 kind: Policy
 # Don't generate audit events for all requests in RequestReceived stage.
 omitStages:


### PR DESCRIPTION
Since k8s v1.12 the API audit.k8s.io has a stable version V1.
1.24 milestone remove audit.k8s.io/v1[alpha|beta]1 versions: [ref](https://github.com/kubernetes/kubernetes/pull/108092)