### PR TITLE
fix sh link error in ubuntu 22.04 LTS

### DIFF
--- a/context/containerd/scripts/init.sh
+++ b/context/containerd/scripts/init.sh
@@ -26,7 +26,7 @@ cp ../bin/* /usr/bin
 
 # Install containerd
 chmod a+x containerd.sh
-sh containerd.sh "$REGISTRY_DOMAIN" "$REGISTRY_PORT"
+/bin/bash containerd.sh "$REGISTRY_DOMAIN" "$REGISTRY_PORT"
 
 # Modify kubelet conf
 mkdir -p /etc/systemd/system/kubelet.service.d
@@ -43,4 +43,4 @@ Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --cgroup-driver=${dri
 eof
 
 chmod a+x init-kube.sh
-sh init-kube.sh
+/bin/bash init-kube.sh


### PR DESCRIPTION
Signed-off-by: Allen Sun <shlallen1990@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
In ubuntu 22.04 LTS, sh will not redirect to /bin/bash.  So when use `sh` may lead to issue, should update that to be `/bin/bash`.
![image](https://user-images.githubusercontent.com/9465626/172612790-89b86ffd-54fb-419b-b445-7b209a319d6f.png)


### Does this pull request fix one issue?

https://github.com/sealerio/sealer/issues/1454
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it


### Describe how to verify it


### Special notes for reviews
